### PR TITLE
Add referrals and mindbody_links tables

### DIFF
--- a/app/models/mindbody_link.rb
+++ b/app/models/mindbody_link.rb
@@ -1,0 +1,20 @@
+class MindbodyLink < ApplicationRecord
+  belongs_to :user
+
+  validates :mindbody_client_id, presence: true, if: :linked?
+
+  scope :linked, -> { where(status: "linked") }
+  scope :pending, -> { where(status: "pending") }
+
+  def linked?
+    status == "linked"
+  end
+
+  def link!(client_id)
+    update!(
+      mindbody_client_id: client_id,
+      status: "linked",
+      linked_at: Time.current
+    )
+  end
+end

--- a/app/models/referral.rb
+++ b/app/models/referral.rb
@@ -1,0 +1,41 @@
+class Referral < ApplicationRecord
+  belongs_to :referrer, class_name: "User"
+  belongs_to :referred, class_name: "User", optional: true
+
+  validates :referral_code, presence: true, uniqueness: true
+  validate :max_active_referrals, on: :create
+
+  before_validation :generate_referral_code, on: :create
+
+  scope :active, -> { where(status: "pending") }
+  scope :completed, -> { where(status: "completed") }
+
+  def complete!(referred_user)
+    update!(
+      referred: referred_user,
+      status: "completed",
+      completed_at: Time.current
+    )
+  end
+
+  def expired?
+    status == "expired"
+  end
+
+  private
+
+  def generate_referral_code
+    self.referral_code ||= loop do
+      code = SecureRandom.alphanumeric(8).upcase
+      break code unless Referral.exists?(referral_code: code)
+    end
+  end
+
+  def max_active_referrals
+    return unless referrer
+
+    if referrer.referrals.active.count >= 5
+      errors.add(:base, "You can only have 5 active referral codes at a time.")
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,6 +11,9 @@ class User < ApplicationRecord
   has_many :reward_redemptions, dependent: :destroy
 
   has_many :deals, through: :deal_claims
+
+  has_many :referrals, foreign_key: :referrer_id, dependent: :destroy
+  has_many :mindbody_links, dependent: :destroy
   has_many :rewards, through: :reward_redemptions
 
   validates :email, presence: true

--- a/db/migrate/20260311072123_create_referrals.rb
+++ b/db/migrate/20260311072123_create_referrals.rb
@@ -1,0 +1,15 @@
+class CreateReferrals < ActiveRecord::Migration[8.1]
+  def change
+    create_table :referrals do |t|
+      t.references :referrer, null: false, foreign_key: { to_table: :users }
+      t.references :referred, null: true, foreign_key: { to_table: :users }
+      t.string :referral_code, null: false
+      t.string :status, default: "pending"
+      t.datetime :completed_at
+
+      t.timestamps
+    end
+
+    add_index :referrals, :referral_code, unique: true
+  end
+end

--- a/db/migrate/20260311072126_create_mindbody_links.rb
+++ b/db/migrate/20260311072126_create_mindbody_links.rb
@@ -1,0 +1,13 @@
+class CreateMindbodyLinks < ActiveRecord::Migration[8.1]
+  def change
+    create_table :mindbody_links do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :mindbody_client_id
+      t.string :status, default: "pending"
+      t.json :match_data
+      t.datetime :linked_at
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -91,6 +91,30 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_11_181158) do
     t.index ["chat_id"], name: "index_messages_on_chat_id"
   end
 
+  create_table "mindbody_links", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "linked_at"
+    t.json "match_data"
+    t.string "mindbody_client_id"
+    t.string "status", default: "pending"
+    t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.index ["user_id"], name: "index_mindbody_links_on_user_id"
+  end
+
+  create_table "referrals", force: :cascade do |t|
+    t.datetime "completed_at"
+    t.datetime "created_at", null: false
+    t.string "referral_code", null: false
+    t.bigint "referred_id"
+    t.bigint "referrer_id", null: false
+    t.string "status", default: "pending"
+    t.datetime "updated_at", null: false
+    t.index ["referral_code"], name: "index_referrals_on_referral_code", unique: true
+    t.index ["referred_id"], name: "index_referrals_on_referred_id"
+    t.index ["referrer_id"], name: "index_referrals_on_referrer_id"
+  end
+
   create_table "reward_redemptions", force: :cascade do |t|
     t.string "code"
     t.datetime "created_at", null: false
@@ -210,6 +234,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_11_181158) do
   add_foreign_key "deal_claims", "users"
   add_foreign_key "deals", "studios"
   add_foreign_key "messages", "chats"
+  add_foreign_key "mindbody_links", "users"
+  add_foreign_key "referrals", "users", column: "referred_id"
+  add_foreign_key "referrals", "users", column: "referrer_id"
   add_foreign_key "reward_redemptions", "rewards"
   add_foreign_key "reward_redemptions", "studios"
   add_foreign_key "reward_redemptions", "users"


### PR DESCRIPTION
## Summary
- Creates `referrals` table (referrer/referred FKs, unique referral_code, status, completed_at)
- Creates `mindbody_links` table (user FK, mindbody_client_id, status, match_data JSON)
- Referral model with code generation, max 5 active codes validation, `complete!` method
- MindbodyLink model with `link!` method, status helpers, scopes
- Adds `has_many :referrals` and `has_many :mindbody_links` to User model

## Test plan
- [ ] Run `bin/rails db:migrate` — two new tables created
- [ ] Verify `Referral.create!` generates unique codes
- [ ] Verify max 5 active referrals validation
- [ ] Verify MindbodyLink status transitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)