### PR TITLE
Add mock Mindbody clients for demo matching

### DIFF
--- a/app/models/mindbody_client.rb
+++ b/app/models/mindbody_client.rb
@@ -1,0 +1,10 @@
+class MindbodyClient < ApplicationRecord
+  belongs_to :studio
+
+  validates :mindbody_client_id, presence: true, uniqueness: { scope: :studio_id }
+  validates :first_name, presence: true
+  validates :last_name, presence: true
+
+  scope :by_phone, ->(phone) { where(phone: phone) }
+  scope :by_name, ->(first, last) { where("LOWER(first_name) = ? AND LOWER(last_name) = ?", first.downcase, last.downcase) }
+end

--- a/app/models/studio.rb
+++ b/app/models/studio.rb
@@ -16,6 +16,7 @@ class Studio < ApplicationRecord
   has_many :studio_classes, dependent: :destroy
   has_many :visits, dependent: :destroy
   has_many :bookings, dependent: :destroy
+  has_many :mindbody_clients, dependent: :destroy
 
   validates :name, presence: true
   validates :slug, presence: true, uniqueness: true

--- a/db/migrate/20260311072540_create_mindbody_clients.rb
+++ b/db/migrate/20260311072540_create_mindbody_clients.rb
@@ -1,0 +1,17 @@
+class CreateMindbodyClients < ActiveRecord::Migration[8.1]
+  def change
+    create_table :mindbody_clients do |t|
+      t.string :first_name
+      t.string :last_name
+      t.string :phone
+      t.string :email
+      t.string :mindbody_client_id
+      t.references :studio, null: false, foreign_key: true
+
+      t.timestamps
+    end
+
+    add_index :mindbody_clients, [:studio_id, :mindbody_client_id], unique: true
+    add_index :mindbody_clients, [:studio_id, :phone]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -91,6 +91,20 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_11_181158) do
     t.index ["chat_id"], name: "index_messages_on_chat_id"
   end
 
+  create_table "mindbody_clients", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "email"
+    t.string "first_name"
+    t.string "last_name"
+    t.string "mindbody_client_id"
+    t.string "phone"
+    t.bigint "studio_id", null: false
+    t.datetime "updated_at", null: false
+    t.index ["studio_id", "mindbody_client_id"], name: "index_mindbody_clients_on_studio_id_and_mindbody_client_id", unique: true
+    t.index ["studio_id", "phone"], name: "index_mindbody_clients_on_studio_id_and_phone"
+    t.index ["studio_id"], name: "index_mindbody_clients_on_studio_id"
+  end
+
   create_table "mindbody_links", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "linked_at"
@@ -234,6 +248,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_11_181158) do
   add_foreign_key "deal_claims", "users"
   add_foreign_key "deals", "studios"
   add_foreign_key "messages", "chats"
+  add_foreign_key "mindbody_clients", "studios"
   add_foreign_key "mindbody_links", "users"
   add_foreign_key "referrals", "users", column: "referred_id"
   add_foreign_key "referrals", "users", column: "referrer_id"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -3,6 +3,9 @@
 # The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
 
 puts "Cleaning database..."
+MindbodyClient.destroy_all
+MindbodyLink.destroy_all
+Referral.destroy_all
 Message.destroy_all
 Chat.destroy_all
 RewardRedemption.destroy_all
@@ -433,6 +436,57 @@ Message.create!(
   sentiment: "neutral",
   content: "You have 9 visits — just 1 more to unlock your free class!",
   summary: "Assistant shared reward progress"
+)
+
+puts "Creating mock Mindbody clients..."
+
+# Scenario 1: Exact phone match with Alice — auto-links on visit 1
+MindbodyClient.create!(
+  studio: studio,
+  mindbody_client_id: "MB-1001",
+  first_name: "Alice",
+  last_name: "Martin",
+  phone: "611234567",
+  email: "alice.martin@gmail.com"
+)
+
+# Scenario 2: No phone match for Bob, but name matches — triggers at visit 10
+MindbodyClient.create!(
+  studio: studio,
+  mindbody_client_id: "MB-1002",
+  first_name: "Bob",
+  last_name: "Chen",
+  phone: "699999999",
+  email: "bob.chen@gmail.com"
+)
+
+# Scenario 3: Client exists in Mindbody but has no TapIn account yet
+MindbodyClient.create!(
+  studio: studio,
+  mindbody_client_id: "MB-1003",
+  first_name: "Diana",
+  last_name: "Rivera",
+  phone: "615551234",
+  email: "diana.r@gmail.com"
+)
+
+# Scenario 4: Duplicate phone — two Mindbody clients with same number (conflict)
+MindbodyClient.create!(
+  studio: studio,
+  mindbody_client_id: "MB-1004",
+  first_name: "Carol",
+  last_name: "Park",
+  phone: "612345678",
+  email: "carol.park@gmail.com"
+)
+
+MindbodyClient.create!(
+  studio: studio,
+  mindbody_client_id: "MB-1005",
+  first_name: "Caroline",
+  last_name: "Parker",
+  phone: "612345678",
+  email: "caroline.p@gmail.com"
 )
 
 puts "Done! Seed data created successfully."


### PR DESCRIPTION
## Summary
- Creates `mindbody_clients` table to simulate Mindbody's client database locally
- Seeds 5 clients covering all matching scenarios: exact phone match, name-only match, no match, phone conflict (2 clients same number)
- Adds `has_many :mindbody_clients` to Studio model

## Test plan
- [ ] Run `bin/rails db:migrate && bin/rails db:seed`
- [ ] Verify 5 MindbodyClient records exist with correct data
- [ ] Verify `by_phone` and `by_name` scopes work

**Depends on:** #1 (referrals-and-mindbody-links)

🤖 Generated with [Claude Code](https://claude.com/claude-code)