### PR TITLE
Add NFC tap & QR check-in landing page

### DIFF
--- a/app/controllers/studios_controller.rb
+++ b/app/controllers/studios_controller.rb
@@ -1,0 +1,13 @@
+class StudiosController < ApplicationController
+  def show
+    @studio = Studio.find_by!(slug: params[:studio_slug])
+    @brand = @studio.studio_brand
+
+    if user_signed_in?
+      redirect_to rewards_path(studio_slug: @studio.slug)
+      # TODO: redirect to dashboard once Iga builds it
+      # redirect_to dashboard_path(studio_slug: @studio.slug)
+    end
+    # Otherwise render the landing page for new/unauthenticated users
+  end
+end

--- a/app/javascript/controllers/nfc_controller.js
+++ b/app/javascript/controllers/nfc_controller.js
@@ -1,0 +1,57 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Handles Web NFC reading on Android Chrome 89+
+// Falls back gracefully — QR codes work on all devices
+export default class extends Controller {
+  static targets = ["status"]
+  static values = { studioSlug: String }
+
+  connect() {
+    if ("NDEFReader" in window) {
+      this.startNfcReader()
+    }
+  }
+
+  async startNfcReader() {
+    try {
+      const reader = new NDEFReader()
+      await reader.scan()
+      this.showStatus("Ready to read NFC tag...", "info")
+
+      reader.addEventListener("reading", (event) => {
+        this.handleNfcRead(event)
+      })
+
+      reader.addEventListener("readingerror", () => {
+        this.showStatus("Could not read NFC tag. Try again.", "error")
+      })
+    } catch (error) {
+      // Permission denied or NFC not available — silent fail, QR is the fallback
+      console.log("NFC not available:", error.message)
+    }
+  }
+
+  handleNfcRead(event) {
+    const decoder = new TextDecoder()
+    for (const record of event.message.records) {
+      if (record.recordType === "url" || record.recordType === "text") {
+        const url = decoder.decode(record.data)
+        if (url.includes(`/s/${this.studioSlugValue}`)) {
+          this.showStatus("NFC tag detected! Checking you in...", "success")
+          // The NFC tag URL points to this page — if user is already here,
+          // the page is already loaded. This confirms the tap was valid.
+          window.location.reload()
+        }
+      }
+    }
+  }
+
+  showStatus(message, type) {
+    if (!this.hasStatusTarget) return
+    this.statusTarget.textContent = message
+    this.statusTarget.style.display = "block"
+    this.statusTarget.style.backgroundColor =
+      type === "success" ? "#d4edda" :
+      type === "error" ? "#f8d7da" : "#d1ecf1"
+  }
+}

--- a/app/views/studios/show.html.erb
+++ b/app/views/studios/show.html.erb
@@ -1,0 +1,90 @@
+<% content_for(:title) { @studio.name } %>
+
+<div class="studio-landing" data-controller="nfc"
+     data-nfc-studio-slug-value="<%= @studio.slug %>">
+
+  <div class="studio-landing__header">
+    <% if @brand&.logo_url.present? %>
+      <img src="<%= @brand.logo_url %>" alt="<%= @studio.name %> logo" class="studio-landing__logo">
+    <% end %>
+    <h1 class="studio-landing__name"><%= @studio.name %></h1>
+    <% if @brand&.tagline.present? %>
+      <p class="studio-landing__tagline"><%= @brand.tagline %></p>
+    <% end %>
+  </div>
+
+  <div class="studio-landing__actions">
+    <!-- TODO: Navid's phone entry form will go here -->
+    <p>Welcome! Enter your phone number to check in.</p>
+    <p class="studio-landing__hint">
+      Tap your phone on the NFC tag or scan the QR code at reception.
+    </p>
+  </div>
+
+  <div class="studio-landing__nfc-status" data-nfc-target="status" style="display: none;">
+  </div>
+</div>
+
+<% if @brand %>
+<style>
+  :root {
+    --studio-primary: <%= @brand.primary_color || '#FF5733' %>;
+    --studio-secondary: <%= @brand.secondary_color || '#33C1FF' %>;
+    --studio-bg: <%= @brand.background_color || '#F5F5F5' %>;
+    --studio-text: <%= @brand.text_color || '#222222' %>;
+  }
+
+  .studio-landing {
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 2rem;
+    background-color: var(--studio-bg);
+    color: var(--studio-text);
+    font-family: <%= @brand.font_body || 'system-ui, sans-serif' %>;
+  }
+
+  .studio-landing__header {
+    text-align: center;
+    margin-bottom: 2rem;
+  }
+
+  .studio-landing__logo {
+    max-width: 120px;
+    margin-bottom: 1rem;
+  }
+
+  .studio-landing__name {
+    font-family: <%= @brand.font_heading || 'system-ui, sans-serif' %>;
+    font-size: 2rem;
+    color: var(--studio-primary);
+    margin: 0;
+  }
+
+  .studio-landing__tagline {
+    color: var(--studio-secondary);
+    font-size: 1.1rem;
+    margin-top: 0.5rem;
+  }
+
+  .studio-landing__actions {
+    text-align: center;
+    max-width: 400px;
+  }
+
+  .studio-landing__hint {
+    font-size: 0.875rem;
+    opacity: 0.7;
+    margin-top: 1rem;
+  }
+
+  .studio-landing__nfc-status {
+    margin-top: 1rem;
+    padding: 0.75rem 1.5rem;
+    border-radius: 8px;
+    font-size: 0.875rem;
+  }
+</style>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,9 @@ Rails.application.routes.draw do
   root to: "pages#home"
 
   scope "/s/:studio_slug" do
+    # NFC/QR landing page — Rajesh
+    get "/", to: "studios#show", as: :studio_landing
+
     resources :rewards, only: [ :index ] do
       post :redeem, to: "reward_redemptions#create", on: :member
     end


### PR DESCRIPTION
## Summary
- `StudiosController#show` at `/s/:studio_slug` — entry point for NFC taps and QR scans
- Studio-branded landing page with CSS custom properties from StudioBrand (colors, fonts, logo)
- Web NFC Stimulus controller for Android Chrome 89+ (silent fallback for unsupported devices)
- Redirects signed-in users to rewards (placeholder until dashboard exists)

## Test plan
- [ ] Visit `/s/tapin-fitness` — see branded landing page
- [ ] Sign in and visit `/s/tapin-fitness` — redirected to rewards
- [ ] NFC controller loads without errors on desktop (graceful no-op)

**Depends on:** #2 (mock-mindbody-clients)

🤖 Generated with [Claude Code](https://claude.com/claude-code)