### PR TITLE
Add customer AI assistant — chat with keyword + LLM

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,3 +73,5 @@ gem "font-awesome-sass", "~> 6.1"
 gem "simple_form"
 
 gem "web-push", "~> 3.1"
+
+gem "ruby_llm", "~> 1.13"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -126,7 +126,18 @@ GEM
     erubi (1.13.1)
     et-orbi (1.4.0)
       tzinfo
+    event_stream_parser (1.0.0)
     execjs (2.10.0)
+    faraday (2.14.1)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
+      logger
+    faraday-multipart (1.2.0)
+      multipart-post (~> 2.0)
+    faraday-net_http (3.4.2)
+      net-http (~> 0.5)
+    faraday-retry (2.4.0)
+      faraday (~> 2.0)
     ffi (1.17.3-aarch64-linux-gnu)
     ffi (1.17.3-aarch64-linux-musl)
     ffi (1.17.3-arm-linux-gnu)
@@ -200,6 +211,9 @@ GEM
       drb (~> 2.0)
       prism (~> 1.5)
     msgpack (1.8.0)
+    multipart-post (2.4.1)
+    net-http (0.9.1)
+      uri (>= 0.11.1)
     net-imap (0.6.3)
       date
       net-protocol
@@ -346,6 +360,17 @@ GEM
     ruby-vips (2.3.0)
       ffi (~> 1.12)
       logger
+    ruby_llm (1.13.2)
+      base64
+      event_stream_parser (~> 1)
+      faraday (>= 2.0)
+      faraday-multipart (>= 1)
+      faraday-net_http (>= 1)
+      faraday-retry (>= 2.0)
+      marcel (~> 1)
+      ruby_llm-schema (~> 0)
+      zeitwerk (~> 2)
+    ruby_llm-schema (0.3.0)
     rubyzip (3.2.2)
     sassc (2.4.0)
       ffi (~> 1.9)
@@ -467,6 +492,7 @@ DEPENDENCIES
   puma (>= 5.0)
   rails (~> 8.1.2)
   rubocop-rails-omakase
+  ruby_llm (~> 1.13)
   sassc-rails
   selenium-webdriver
   simple_form
@@ -521,7 +547,12 @@ CHECKSUMS
   erb (6.0.2) sha256=9fe6264d44f79422c87490a1558479bd0e7dad4dd0e317656e67ea3077b5242b
   erubi (1.13.1) sha256=a082103b0885dbc5ecf1172fede897f9ebdb745a4b97a5e8dc63953db1ee4ad9
   et-orbi (1.4.0) sha256=6c7e3c90779821f9e3b324c5e96fda9767f72995d6ae435b96678a4f3e2de8bc
+  event_stream_parser (1.0.0) sha256=a2683bab70126286f8184dc88f7968ffc4028f813161fb073ec90d171f7de3c8
   execjs (2.10.0) sha256=6bcb8be8f0052ff9d370b65d1c080f2406656e150452a0abdb185a133048450d
+  faraday (2.14.1) sha256=a43cceedc1e39d188f4d2cdd360a8aaa6a11da0c407052e426ba8d3fb42ef61c
+  faraday-multipart (1.2.0) sha256=7d89a949693714176f612323ca13746a2ded204031a6ba528adee788694ef757
+  faraday-net_http (3.4.2) sha256=f147758260d3526939bf57ecf911682f94926a3666502e24c69992765875906c
+  faraday-retry (2.4.0) sha256=7b79c48fb7e56526faf247b12d94a680071ff40c9fda7cf1ec1549439ad11ebe
   ffi (1.17.3-aarch64-linux-gnu) sha256=28ad573df26560f0aedd8a90c3371279a0b2bd0b4e834b16a2baa10bd7a97068
   ffi (1.17.3-aarch64-linux-musl) sha256=020b33b76775b1abacc3b7d86b287cef3251f66d747092deec592c7f5df764b2
   ffi (1.17.3-arm-linux-gnu) sha256=5bd4cea83b68b5ec0037f99c57d5ce2dd5aa438f35decc5ef68a7d085c785668
@@ -555,6 +586,8 @@ CHECKSUMS
   mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
   minitest (6.0.2) sha256=db6e57956f6ecc6134683b4c87467d6dd792323c7f0eea7b93f66bd284adbc3d
   msgpack (1.8.0) sha256=e64ce0212000d016809f5048b48eb3a65ffb169db22238fb4b72472fecb2d732
+  multipart-post (2.4.1) sha256=9872d03a8e552020ca096adadbf5e3cb1cd1cdd6acd3c161136b8a5737cdb4a8
+  net-http (0.9.1) sha256=25ba0b67c63e89df626ed8fac771d0ad24ad151a858af2cc8e6a716ca4336996
   net-imap (0.6.3) sha256=9bab75f876596d09ee7bf911a291da478e0cd6badc54dfb82874855ccc82f2ad
   net-pop (0.1.2) sha256=848b4e982013c15b2f0382792268763b748cce91c9e91e36b0f27ed26420dff3
   net-protocol (0.2.2) sha256=aa73e0cba6a125369de9837b8d8ef82a61849360eba0521900e2c3713aa162a8
@@ -615,6 +648,8 @@ CHECKSUMS
   rubocop-rails-omakase (1.1.0) sha256=2af73ac8ee5852de2919abbd2618af9c15c19b512c4cfc1f9a5d3b6ef009109d
   ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
   ruby-vips (2.3.0) sha256=e685ec02c13969912debbd98019e50492e12989282da5f37d05f5471442f5374
+  ruby_llm (1.13.2) sha256=f8bd7fa0e3c486368b318167775eac086896e3477986ad5ca2c3b38b1e2913c5
+  ruby_llm-schema (0.3.0) sha256=a591edc5ca1b7f0304f0e2261de61ba4b3bea17be09f5cf7558153adfda3dec6
   rubyzip (3.2.2) sha256=c0ed99385f0625415c8f05bcae33fe649ed2952894a95ff8b08f26ca57ea5b3c
   sassc (2.4.0) sha256=4c60a2b0a3b36685c83b80d5789401c2f678c1652e3288315a1551d811d9f83e
   sassc-rails (2.1.2) sha256=5f4fdf3881fc9bdc8e856ffbd9850d70a2878866feae8114aa45996179952db5

--- a/app/controllers/chats_controller.rb
+++ b/app/controllers/chats_controller.rb
@@ -1,0 +1,31 @@
+class ChatsController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_chat, only: [:show]
+
+  def index
+    @chats = current_user.chats.order(created_at: :asc)
+  end
+
+  def show
+    @chats = current_user.chats.order(created_at: :asc)
+    @messages = @chat.messages.order(created_at: :asc)
+  end
+
+  def create
+    studio = Studio.find_by(slug: params[:studio_slug]) || current_user.visits.last&.studio
+
+    unless studio
+      redirect_to root_path, alert: "No studio found"
+      return
+    end
+
+    chat = current_user.chats.create!(studio: studio)
+    redirect_to chat_path(chat)
+  end
+
+  private
+
+  def set_chat
+    @chat = current_user.chats.find(params[:id])
+  end
+end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,0 +1,127 @@
+class MessagesController < ApplicationController
+  before_action :authenticate_user!
+
+  SYSTEM_PROMPT = <<~PROMPT
+    You are the TapIn AI assistant helping users at a fitness studio.
+    You help with check-ins, rewards, loyalty progress, classes, deals, and general studio info.
+    Be concise, friendly, and helpful. Use the data provided — never make up numbers.
+  PROMPT
+
+  def create
+    @chat = current_user.chats.find(params[:chat_id])
+    @studio = @chat.studio
+
+    user_text = params[:message].to_s.strip
+    return render json: { error: "empty_message" }, status: :unprocessable_entity if user_text.blank?
+
+    # Save user message
+    Message.create!(role: "user", content: user_text, chat: @chat)
+
+    # Generate response
+    assistant_text = generate_customer_response(user_text)
+
+    # Save assistant message
+    Message.create!(role: "assistant", content: assistant_text, chat: @chat)
+
+    # Auto-rename chat from first message
+    new_title = maybe_rename_chat(user_text)
+
+    render json: { assistant: assistant_text, title: new_title }
+  end
+
+  private
+
+  def maybe_rename_chat(user_text)
+    return nil unless @chat.title&.match?(/\AChat \d+\z/)
+
+    title = user_text.truncate(40, omission: "...")
+    @chat.update!(title: title)
+    title
+  end
+
+  def generate_customer_response(user_text)
+    text = user_text.downcase
+
+    case text
+    when /check.?in|visit|attendance|how many/
+      count = current_user.visits_count_for(@studio)
+      progress = current_user.current_visit_progress_for(@studio)
+      remaining = current_user.visits_remaining_for_next_reward(@studio)
+      "You have #{count} visits at #{@studio.name}! " \
+      "You're #{progress}/10 towards your next free class (#{remaining} more to go)."
+
+    when /reward|unlock|earn|free class|milestone/
+      if current_user.free_class_reward_available_for?(@studio)
+        "You have a free class reward available! Head to the rewards page to redeem it."
+      else
+        remaining = current_user.visits_remaining_for_next_reward(@studio)
+        progress = current_user.current_visit_progress_for(@studio)
+        "You're #{progress}/10 visits towards your next free class. #{remaining} more to go — keep it up!"
+      end
+
+    when /class|recommend|workout|exercise|train|schedule/
+      classes = @studio.class_configs.pluck(:class_name, :point_value, :is_premium)
+      lines = classes.map do |name, pts, premium|
+        "#{name} (#{pts} pts#{premium ? ', premium' : ''})"
+      end
+      "Classes at #{@studio.name}:\n#{lines.join("\n")}"
+
+    when /deal|offer|discount|promo|special/
+      deals = @studio.deals.active.pluck(:name, :discount_percent)
+      if deals.any?
+        lines = deals.map { |name, pct| "#{name} — #{pct}% off" }
+        "Active deals:\n#{lines.join("\n")}"
+      else
+        "No active deals right now, but check back soon!"
+      end
+
+    when /book|upcoming|next class|my class/
+      bookings = current_user.bookings.where(studio: @studio, status: true)
+                             .where("class_time > ?", Time.current)
+                             .order(:class_time).limit(3)
+      if bookings.any?
+        lines = bookings.map { |b| "#{b.class_name} — #{b.class_time.strftime('%a %b %d, %-I:%M %p')}" }
+        "Your upcoming classes:\n#{lines.join("\n")}"
+      else
+        "You don't have any upcoming bookings. Check out the class schedule!"
+      end
+
+    when /referral|invite|friend|share/
+      active = current_user.referrals.active.count
+      "You have #{active}/5 active referral links. Share one with a friend — you'll both get 50% off when they complete their first visit!"
+
+    when /point|progress|status|tier/
+      count = current_user.visits_count_for(@studio)
+      milestones = current_user.reward_milestones_reached_for(@studio)
+      remaining = current_user.visits_remaining_for_next_reward(@studio)
+      "You have #{count} total visits and #{milestones} milestone(s) reached. " \
+      "#{remaining} more visit(s) until your next free class!"
+
+    when /hi|hello|hey|help|what can you/
+      name = current_user.first_name.present? ? ", #{current_user.first_name}" : ""
+      "Hey#{name}! I can help you with:\n" \
+      "- Your visit count and reward progress\n" \
+      "- Available rewards and deals\n" \
+      "- Class schedule and bookings\n" \
+      "- Referral links\n" \
+      "Just ask me anything!"
+
+    else
+      call_llm
+    end
+  end
+
+  def call_llm
+    chat = RubyLLM.chat(model: "gpt-4.1-mini")
+
+    history = @chat.messages.order(:created_at).map do |m|
+      { role: m.role, content: m.content }
+    end
+
+    response = chat.with_instructions(SYSTEM_PROMPT).ask(history)
+    response.content
+  rescue StandardError => e
+    Rails.logger.error("LLM error: #{e.class} - #{e.message}")
+    "I'm not sure how to help with that yet. Try asking about your visits, rewards, classes, or deals!"
+  end
+end

--- a/app/javascript/controllers/chat_shell_controller.js
+++ b/app/javascript/controllers/chat_shell_controller.js
@@ -1,0 +1,146 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["messages", "input", "sendBtn", "suggestions", "welcome", "overlay", "sidebar", "chatTitle"]
+  static values = { chatId: Number }
+
+  connect() {
+    this.scrollToBottom()
+  }
+
+  async send(event) {
+    event.preventDefault()
+    const message = this.inputTarget.value.trim()
+    if (message === "") return
+
+    this.appendUserMessage(message)
+    this.inputTarget.value = ""
+    this.appendTyping()
+    this.disableInput()
+    this.hideWelcome()
+
+    await this.postMessage(message)
+  }
+
+  async sendSuggestion(event) {
+    event.preventDefault()
+    const message = event.currentTarget.dataset.message
+    if (!message) return
+
+    this.appendUserMessage(message)
+    this.appendTyping()
+    this.disableInput()
+    this.hideWelcome()
+
+    await this.postMessage(message)
+  }
+
+  async postMessage(message) {
+    try {
+      const formData = new FormData()
+      formData.append("message", message)
+
+      const response = await fetch(`/chats/${this.chatIdValue}/messages`, {
+        method: "POST",
+        headers: {
+          "X-CSRF-Token": document.querySelector("meta[name='csrf-token']").content,
+          "Accept": "application/json"
+        },
+        body: formData
+      })
+
+      if (!response.ok) throw new Error("Request failed")
+
+      const data = await response.json()
+      this.removeTyping()
+      this.appendAssistantMessage(data.assistant)
+
+      if (data.title && this.hasChatTitleTarget) {
+        this.chatTitleTarget.textContent = data.title
+      }
+    } catch (error) {
+      this.removeTyping()
+      this.appendAssistantMessage("Sorry, something went wrong. Please try again.")
+    } finally {
+      this.enableInput()
+    }
+  }
+
+  appendUserMessage(text) {
+    const html = `
+      <div class="chat-row chat-row--user">
+        <div class="chat-bubble chat-bubble--user">${this.escapeHtml(text)}</div>
+        <div class="chat-avatar chat-avatar--user">You</div>
+      </div>`
+    this.messagesTarget.insertAdjacentHTML("beforeend", html)
+    this.scrollToBottom()
+  }
+
+  appendAssistantMessage(text) {
+    const formatted = this.escapeHtml(text).replace(/\n/g, "<br>")
+    const html = `
+      <div class="chat-row chat-row--assistant">
+        <div class="chat-avatar chat-avatar--ai">AI</div>
+        <div class="chat-bubble chat-bubble--assistant">${formatted}</div>
+      </div>`
+    this.messagesTarget.insertAdjacentHTML("beforeend", html)
+    this.scrollToBottom()
+  }
+
+  appendTyping() {
+    const html = `
+      <div class="chat-row chat-row--assistant" id="typing-indicator">
+        <div class="chat-avatar chat-avatar--ai">AI</div>
+        <div class="typing-indicator">
+          <span class="dot"></span>
+          <span class="dot"></span>
+          <span class="dot"></span>
+        </div>
+      </div>`
+    this.messagesTarget.insertAdjacentHTML("beforeend", html)
+    this.scrollToBottom()
+  }
+
+  removeTyping() {
+    const el = document.getElementById("typing-indicator")
+    if (el) el.remove()
+  }
+
+  hideWelcome() {
+    if (this.hasWelcomeTarget) this.welcomeTarget.remove()
+    if (this.hasSuggestionsTarget) this.suggestionsTarget.remove()
+  }
+
+  disableInput() {
+    this.inputTarget.disabled = true
+    if (this.hasSendBtnTarget) this.sendBtnTarget.disabled = true
+  }
+
+  enableInput() {
+    this.inputTarget.disabled = false
+    if (this.hasSendBtnTarget) this.sendBtnTarget.disabled = false
+    this.inputTarget.focus()
+  }
+
+  scrollToBottom() {
+    requestAnimationFrame(() => {
+      this.messagesTarget.scrollTop = this.messagesTarget.scrollHeight
+    })
+  }
+
+  openSidebar() {
+    if (this.hasSidebarTarget) this.sidebarTarget.classList.add("chat-sidebar-open")
+    if (this.hasOverlayTarget) this.overlayTarget.style.display = "block"
+  }
+
+  closeSidebar() {
+    if (this.hasSidebarTarget) this.sidebarTarget.classList.remove("chat-sidebar-open")
+    if (this.hasOverlayTarget) this.overlayTarget.style.display = "none"
+  }
+
+  escapeHtml(text) {
+    const div = document.createElement("div")
+    div.textContent = text
+    return div.innerHTML
+  }
+}

--- a/app/models/chat.rb
+++ b/app/models/chat.rb
@@ -3,4 +3,13 @@ class Chat < ApplicationRecord
   belongs_to :studio
 
   has_many :messages, dependent: :destroy
+
+  before_create :set_title
+
+  private
+
+  def set_title
+    count = Chat.where(user_id: user_id).count + 1
+    self.title ||= "Chat #{count}"
+  end
 end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,3 +1,6 @@
 class Message < ApplicationRecord
   belongs_to :chat
+
+  validates :role, presence: true
+  validates :content, presence: true
 end

--- a/app/views/chats/index.html.erb
+++ b/app/views/chats/index.html.erb
@@ -1,0 +1,63 @@
+<% content_for(:title) { "Your Conversations" } %>
+
+<div class="chat-list-container">
+  <div class="chat-list-header">
+    <div>
+      <h2>Your conversations</h2>
+      <p>Chat with your TapIn AI assistant</p>
+    </div>
+    <%= button_to chats_path, method: :post, class: "chat-new-btn" do %>
+      + New chat
+    <% end %>
+  </div>
+
+  <% if @chats.present? %>
+    <div class="chat-list">
+      <% @chats.reverse.each do |chat| %>
+        <%= link_to chat_path(chat), class: "chat-list-item" do %>
+          <div class="chat-list-item__avatar">AI</div>
+          <div class="chat-list-item__content">
+            <div class="chat-list-item__top">
+              <span class="chat-list-item__title"><%= chat.title %></span>
+              <span class="chat-list-item__time"><%= time_ago_in_words(chat.updated_at) %> ago</span>
+            </div>
+            <% last_msg = chat.messages.order(created_at: :desc).first %>
+            <p class="chat-list-item__preview">
+              <%= last_msg ? truncate(last_msg.content, length: 80) : "No messages yet" %>
+            </p>
+          </div>
+        <% end %>
+      <% end %>
+    </div>
+  <% else %>
+    <div class="chat-empty">
+      <div class="chat-empty__avatar">AI</div>
+      <h3>Start your first conversation</h3>
+      <p>Ask about visits, rewards, classes, deals, and more.</p>
+      <%= button_to chats_path, method: :post, class: "chat-new-btn" do %>
+        Start chatting
+      <% end %>
+    </div>
+  <% end %>
+</div>
+
+<style>
+  .chat-list-container { max-width: 720px; margin: 2rem auto; padding: 0 1rem; }
+  .chat-list-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 1.5rem; }
+  .chat-list-header h2 { margin: 0; font-size: 1.5rem; }
+  .chat-list-header p { margin: 0; color: #666; font-size: 0.875rem; }
+  .chat-new-btn { padding: 0.5rem 1.25rem; background: #4F46E5; color: white; border: none; border-radius: 20px; cursor: pointer; font-weight: 600; }
+  .chat-list { display: flex; flex-direction: column; gap: 0.5rem; }
+  .chat-list-item { display: flex; gap: 0.75rem; padding: 1rem; background: white; border-radius: 12px; text-decoration: none; color: inherit; border: 1px solid #eee; }
+  .chat-list-item:hover { border-color: #4F46E5; }
+  .chat-list-item__avatar { width: 40px; height: 40px; border-radius: 50%; background: #4F46E5; color: white; display: flex; align-items: center; justify-content: center; font-weight: 700; font-size: 0.8rem; flex-shrink: 0; }
+  .chat-list-item__content { flex: 1; min-width: 0; }
+  .chat-list-item__top { display: flex; justify-content: space-between; }
+  .chat-list-item__title { font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .chat-list-item__time { color: #999; font-size: 0.8rem; flex-shrink: 0; }
+  .chat-list-item__preview { color: #666; font-size: 0.875rem; margin: 0.25rem 0 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .chat-empty { text-align: center; padding: 3rem 0; }
+  .chat-empty__avatar { width: 56px; height: 56px; border-radius: 50%; background: #4F46E5; color: white; display: flex; align-items: center; justify-content: center; font-weight: 700; margin: 0 auto 1rem; }
+  .chat-empty h3 { margin-bottom: 0.5rem; }
+  .chat-empty p { color: #666; margin-bottom: 1.5rem; }
+</style>

--- a/app/views/chats/show.html.erb
+++ b/app/views/chats/show.html.erb
@@ -1,0 +1,159 @@
+<% content_for(:title) { @chat.title } %>
+
+<div class="chat-wrapper" data-controller="chat-shell" data-chat-shell-chat-id-value="<%= @chat.id %>">
+
+  <%# Header bar %>
+  <div class="chat-header">
+    <button type="button" class="chat-header__history-btn" data-action="click->chat-shell#openSidebar">
+      History
+    </button>
+    <span class="chat-header__title" data-chat-shell-target="chatTitle"><%= @chat.title %></span>
+    <div class="chat-header__actions">
+      <%= button_to chats_path, method: :post, class: "chat-new-btn" do %>
+        + New chat
+      <% end %>
+    </div>
+  </div>
+
+  <%# Messages area %>
+  <div class="chat-messages" data-chat-shell-target="messages">
+    <% if @messages.present? %>
+      <% @messages.each do |m| %>
+        <% if m.role == "user" %>
+          <div class="chat-row chat-row--user">
+            <div class="chat-bubble chat-bubble--user"><%= simple_format(m.content, {}, wrapper_tag: "span") %></div>
+            <div class="chat-avatar chat-avatar--user">You</div>
+          </div>
+        <% else %>
+          <div class="chat-row chat-row--assistant">
+            <div class="chat-avatar chat-avatar--ai">AI</div>
+            <div class="chat-bubble chat-bubble--assistant"><%= simple_format(m.content, {}, wrapper_tag: "span") %></div>
+          </div>
+        <% end %>
+      <% end %>
+    <% else %>
+      <%# Welcome state %>
+      <div class="chat-welcome" data-chat-shell-target="welcome">
+        <div class="chat-avatar chat-avatar--ai chat-welcome__avatar">AI</div>
+        <h3>Hi<%= current_user.first_name.present? ? ", #{current_user.first_name}" : "" %>!</h3>
+        <p>I'm your TapIn assistant. Ask me about your visits, rewards, classes, or deals.</p>
+      </div>
+
+      <%# Suggestion chips %>
+      <div class="suggestion-chips" data-chat-shell-target="suggestions">
+        <button class="suggestion-chip" data-action="click->chat-shell#sendSuggestion" data-message="How many visits do I have?">
+          My visits
+        </button>
+        <button class="suggestion-chip" data-action="click->chat-shell#sendSuggestion" data-message="What rewards can I unlock?">
+          Rewards
+        </button>
+        <button class="suggestion-chip" data-action="click->chat-shell#sendSuggestion" data-message="Recommend a class for me">
+          Classes
+        </button>
+        <button class="suggestion-chip" data-action="click->chat-shell#sendSuggestion" data-message="Show me current deals">
+          Deals
+        </button>
+      </div>
+    <% end %>
+  </div>
+
+  <%# Input area %>
+  <div class="chat-input-area">
+    <form class="chat-input-form" data-action="submit->chat-shell#send">
+      <input type="text"
+             name="message"
+             class="chat-input"
+             placeholder="Type a message..."
+             autocomplete="off"
+             data-chat-shell-target="input">
+      <button type="submit" class="chat-send-btn" data-chat-shell-target="sendBtn">
+        Send
+      </button>
+    </form>
+  </div>
+
+  <%# Sidebar overlay %>
+  <div class="chat-overlay" style="display:none;"
+       data-chat-shell-target="overlay"
+       data-action="click->chat-shell#closeSidebar">
+  </div>
+
+  <%# Sidebar %>
+  <aside class="chat-sidebar" data-chat-shell-target="sidebar">
+    <div class="chat-sidebar__header">
+      <div>
+        <strong>Your chats</strong>
+        <div class="chat-sidebar__count"><%= @chats.size %> conversation<%= @chats.size == 1 ? '' : 's' %></div>
+      </div>
+      <button type="button" class="chat-sidebar__close" data-action="click->chat-shell#closeSidebar">&times;</button>
+    </div>
+
+    <div class="chat-sidebar__new">
+      <%= button_to chats_path, method: :post, class: "chat-new-btn chat-new-btn--full" do %>
+        + New chat
+      <% end %>
+    </div>
+
+    <div class="chat-sidebar__list">
+      <% @chats.each do |chat| %>
+        <%= link_to chat_path(chat), class: "chat-sidebar__item #{'chat-sidebar__item--active' if chat.id == @chat.id}" do %>
+          <div class="chat-sidebar__item-title"><%= chat.title %></div>
+          <div class="chat-sidebar__item-time"><%= time_ago_in_words(chat.updated_at) %> ago</div>
+        <% end %>
+      <% end %>
+    </div>
+  </aside>
+</div>
+
+<style>
+  .chat-wrapper { display: flex; flex-direction: column; height: 100vh; position: relative; }
+  .chat-header { display: flex; align-items: center; gap: 0.75rem; padding: 0.75rem 1rem; background: white; border-bottom: 1px solid #eee; }
+  .chat-header__history-btn { padding: 0.375rem 0.75rem; background: #f3f4f6; border: 1px solid #ddd; border-radius: 16px; cursor: pointer; font-size: 0.875rem; }
+  .chat-header__title { font-weight: 600; }
+  .chat-header__actions { margin-left: auto; }
+  .chat-new-btn { padding: 0.375rem 1rem; background: #4F46E5; color: white; border: none; border-radius: 16px; cursor: pointer; font-weight: 600; font-size: 0.875rem; }
+  .chat-new-btn--full { width: 100%; }
+
+  .chat-messages { flex: 1; overflow-y: auto; padding: 1rem; }
+  .chat-row { display: flex; align-items: flex-end; gap: 0.5rem; margin-bottom: 0.75rem; }
+  .chat-row--user { justify-content: flex-end; }
+  .chat-row--assistant { justify-content: flex-start; }
+  .chat-avatar { width: 32px; height: 32px; border-radius: 50%; display: flex; align-items: center; justify-content: center; font-size: 0.7rem; font-weight: 700; flex-shrink: 0; }
+  .chat-avatar--ai { background: #4F46E5; color: white; }
+  .chat-avatar--user { background: #e5e7eb; color: #374151; }
+  .chat-bubble { max-width: 75%; padding: 0.75rem 1rem; border-radius: 16px; line-height: 1.5; font-size: 0.9375rem; }
+  .chat-bubble--user { background: #4F46E5; color: white; border-bottom-right-radius: 4px; }
+  .chat-bubble--assistant { background: #f3f4f6; color: #1f2937; border-bottom-left-radius: 4px; }
+
+  .chat-welcome { text-align: center; padding: 3rem 1rem 1rem; }
+  .chat-welcome__avatar { width: 48px; height: 48px; font-size: 1rem; margin: 0 auto 1rem; }
+  .suggestion-chips { display: flex; flex-wrap: wrap; justify-content: center; gap: 0.5rem; padding: 0 1rem; }
+  .suggestion-chip { padding: 0.5rem 1rem; background: white; border: 1px solid #ddd; border-radius: 20px; cursor: pointer; font-size: 0.875rem; }
+  .suggestion-chip:hover { border-color: #4F46E5; color: #4F46E5; }
+
+  .chat-input-area { padding: 0.75rem 1rem; border-top: 1px solid #eee; background: white; }
+  .chat-input-form { display: flex; gap: 0.5rem; }
+  .chat-input { flex: 1; padding: 0.75rem 1rem; border: 1px solid #ddd; border-radius: 20px; font-size: 0.9375rem; outline: none; }
+  .chat-input:focus { border-color: #4F46E5; }
+  .chat-send-btn { padding: 0.75rem 1.25rem; background: #4F46E5; color: white; border: none; border-radius: 20px; cursor: pointer; font-weight: 600; }
+
+  .chat-overlay { position: fixed; top: 0; left: 0; width: 100%; height: 100%; background: rgba(0,0,0,0.4); z-index: 1060; }
+  .chat-sidebar { position: fixed; top: 0; left: -300px; width: 300px; height: 100%; background: white; box-shadow: 2px 0 8px rgba(0,0,0,0.1); z-index: 1070; transition: left 0.2s; }
+  .chat-sidebar-open { left: 0; }
+  .chat-sidebar__header { display: flex; justify-content: space-between; align-items: center; padding: 1rem; border-bottom: 1px solid #eee; }
+  .chat-sidebar__count { font-size: 0.8rem; color: #666; }
+  .chat-sidebar__close { background: none; border: none; font-size: 1.5rem; cursor: pointer; color: #666; }
+  .chat-sidebar__new { padding: 0.5rem; }
+  .chat-sidebar__list { overflow-y: auto; height: calc(100% - 140px); padding: 0.5rem; }
+  .chat-sidebar__item { display: block; padding: 0.75rem; border-radius: 8px; text-decoration: none; color: inherit; margin-bottom: 0.25rem; }
+  .chat-sidebar__item:hover { background: #f3f4f6; }
+  .chat-sidebar__item--active { background: #EEF2FF; }
+  .chat-sidebar__item-title { font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .chat-sidebar__item-time { font-size: 0.75rem; color: #999; }
+
+  .typing-indicator { display: flex; gap: 4px; padding: 0.75rem 1rem; background: #f3f4f6; border-radius: 16px; }
+  .typing-indicator .dot { width: 8px; height: 8px; background: #9ca3af; border-radius: 50%; animation: typing 1.2s infinite ease-in-out; }
+  .typing-indicator .dot:nth-child(2) { animation-delay: 0.2s; }
+  .typing-indicator .dot:nth-child(3) { animation-delay: 0.4s; }
+  @keyframes typing { 0%, 60%, 100% { transform: translateY(0); } 30% { transform: translateY(-4px); } }
+</style>

--- a/config/initializers/ruby_llm.rb
+++ b/config/initializers/ruby_llm.rb
@@ -1,0 +1,3 @@
+RubyLLM.configure do |config|
+  config.openai_api_key = ENV.fetch("OPENAI_API_KEY", nil)
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,6 +37,11 @@ Rails.application.routes.draw do
 
   resources :visits, only: [:create]
 
+  # AI Assistant — Rajesh
+  resources :chats, only: [:index, :show, :create] do
+    resources :messages, only: [:create]
+  end
+
   # Push notification subscription — Rajesh
   resources :push_subscriptions, only: [:create]
 

--- a/db/migrate/20260311080211_add_title_to_chats.rb
+++ b/db/migrate/20260311080211_add_title_to_chats.rb
@@ -1,0 +1,5 @@
+class AddTitleToChats < ActiveRecord::Migration[8.1]
+  def change
+    add_column :chats, :title, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -34,6 +34,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_11_181158) do
     t.datetime "created_at", null: false
     t.boolean "status"
     t.bigint "studio_id", null: false
+    t.string "title"
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
     t.index ["studio_id"], name: "index_chats_on_studio_id"


### PR DESCRIPTION
## Summary
Ported and adapted from [TAPIN_AI_ASSISTANT](https://github.com/YGAGREGORIA/TAPIN_AI_ASSISTANT) repo.

- `ChatsController`: index (conversation list), show (chat room), create (new chat)
- `MessagesController`: keyword matching for visits, rewards, classes, deals, bookings, referrals + RubyLLM fallback to GPT-4.1-mini
- `chat_shell` Stimulus controller: real-time chat UI with typing indicator, suggestion chips, sidebar history, auto-rename
- Chat views: index + show with plain CSS
- Added `ruby_llm` gem, title column on chats

Adapted: CheckIn→Visit, Course→ClassConfig, tier system→milestone system.

## Test plan
- [ ] Visit `/chats` — see conversation list
- [ ] Create new chat → redirected to chat room
- [ ] Type "How many visits do I have?" → get visit count response
- [ ] Type "What rewards can I unlock?" → get milestone progress
- [ ] Suggestion chips trigger correct responses
- [ ] Chat auto-renames from first message

**Depends on:** #6 (notifications)

🤖 Generated with [Claude Code](https://claude.com/claude-code)