### PR TITLE
Add Heroku deploy config for lewagon-tapin.xyz

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,3 @@
+web: bundle exec puma -C config/puma.rb
+worker: bundle exec rake solid_queue:start
+release: bundle exec rails db:migrate

--- a/config/database.yml
+++ b/config/database.yml
@@ -87,18 +87,13 @@ test:
 production:
   primary: &primary_production
     <<: *default
-    database: tapin_project_final_production
-    username: tapin_project_final
-    password: <%= ENV["TAPIN_PROJECT_FINAL_DATABASE_PASSWORD"] %>
+    url: <%= ENV["DATABASE_URL"] %>
   cache:
     <<: *primary_production
-    database: tapin_project_final_production_cache
     migrations_paths: db/cache_migrate
   queue:
     <<: *primary_production
-    database: tapin_project_final_production_queue
     migrations_paths: db/queue_migrate
   cable:
     <<: *primary_production
-    database: tapin_project_final_production_cable
     migrations_paths: db/cable_migrate

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -24,14 +24,14 @@ Rails.application.configure do
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :local
 
-  # Assume all access to the app is happening through a SSL-terminating reverse proxy.
-  # config.assume_ssl = true
+  # Heroku terminates SSL at the router
+  config.assume_ssl = true
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Skip http-to-https redirect for the default health check endpoint.
-  # config.ssl_options = { redirect: { exclude: ->(request) { request.path == "/up" } } }
+  config.ssl_options = { redirect: { exclude: ->(request) { request.path == "/up" } } }
 
   # Log to STDOUT with the current request id as a default log tag.
   config.log_tags = [ :request_id ]
@@ -51,14 +51,14 @@ Rails.application.configure do
 
   # Replace the default in-process and non-durable queuing backend for Active Job.
   config.active_job.queue_adapter = :solid_queue
-  config.solid_queue.connects_to = { database: { writing: :queue } }
+  config.solid_queue.connects_to = { database: { writing: :queue, reading: :queue } }
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false
 
   # Set host to be used by links generated in mailer templates.
-  config.action_mailer.default_url_options = { host: "example.com" }
+  config.action_mailer.default_url_options = { host: "lewagon-tapin.xyz" }
 
   # Specify outgoing SMTP server. Remember to add smtp/* credentials via bin/rails credentials:edit.
   # config.action_mailer.smtp_settings = {
@@ -80,11 +80,12 @@ Rails.application.configure do
   config.active_record.attributes_for_inspect = [ :id ]
 
   # Enable DNS rebinding protection and other `Host` header attacks.
-  # config.hosts = [
-  #   "example.com",     # Allow requests from example.com
-  #   /.*\.example\.com/ # Allow requests from subdomains like `www.example.com`
-  # ]
-  #
+  config.hosts = [
+    "lewagon-tapin.xyz",
+    /.*\.lewagon-tapin\.xyz/,
+    /.*\.herokuapp\.com/
+  ]
+
   # Skip DNS rebinding protection for the default health check endpoint.
-  # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
+  config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
 end


### PR DESCRIPTION
## Summary
- Adds `Procfile` for Heroku (web: Puma, worker: Solid Queue, release: db:migrate)
- Updates `database.yml` to use `DATABASE_URL` env var (single Heroku Postgres DB shared for primary/cache/queue/cable)
- Enables SSL and host authorization for `lewagon-tapin.xyz` and `*.herokuapp.com`
- Sets mailer default host to `lewagon-tapin.xyz`

## Deploy steps after merge
1. `heroku create tapin-app` (or your preferred app name)
2. `heroku addons:create heroku-postgresql:essential-0`
3. `heroku config:set RAILS_MASTER_KEY=$(cat config/master.key)`
4. `git push heroku main`
5. `heroku run rails db:seed`
6. Add custom domain: `heroku domains:add lewagon-tapin.xyz`
7. Point DNS: CNAME `lewagon-tapin.xyz` → Heroku DNS target

## Test plan
- [ ] `heroku local` runs without errors
- [ ] Deploy to Heroku staging and verify `/up` health check
- [ ] Verify SSL redirect works
- [ ] Verify `lewagon-tapin.xyz` resolves after DNS propagation

🤖 Generated with [Claude Code](https://claude.com/claude-code)