### PR TITLE
Add admin namespace — role enum, BaseController, layout

### DIFF
--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -1,0 +1,18 @@
+class Admin::BaseController < ApplicationController
+  layout "admin"
+  before_action :authenticate_user!
+  before_action :require_admin!
+  helper_method :current_studio
+
+  private
+
+  def current_studio
+    @current_studio ||= current_user.studios.first
+  end
+
+  def require_admin!
+    unless current_user&.admin?
+      redirect_to root_path, alert: "You are not authorized to access this page."
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,8 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
+  enum :role, { customer: 0, admin: 1 }
+
   has_many :studios, dependent: :destroy
   has_many :chats, dependent: :destroy
   has_many :messages, through: :chats

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>TapIn Admin — <%= content_for(:title) || "Dashboard" %></title>
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <%= csrf_meta_tags %>
+    <%= csp_meta_tag %>
+
+    <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
+    <%= javascript_importmap_tags %>
+  </head>
+
+  <body>
+    <div class="d-flex">
+      <!-- Sidebar -->
+      <nav class="bg-dark text-white p-3" style="width: 240px; min-height: 100vh;">
+        <h5 class="mb-4">TapIn Admin</h5>
+        <ul class="nav flex-column">
+          <li class="nav-item">
+            <%= link_to "Home", "#", class: "nav-link text-white" %>
+          </li>
+          <li class="nav-item">
+            <%= link_to "Members", "#", class: "nav-link text-white-50" %>
+          </li>
+          <li class="nav-item">
+            <%= link_to "Loyalty", "#", class: "nav-link text-white-50" %>
+          </li>
+          <li class="nav-item">
+            <%= link_to "Mindbody", "#", class: "nav-link text-white-50" %>
+          </li>
+          <li class="nav-item">
+            <%= link_to "Branding", "#", class: "nav-link text-white-50" %>
+          </li>
+          <li class="nav-item">
+            <%= link_to "Messages", "#", class: "nav-link text-white-50" %>
+          </li>
+          <li class="nav-item">
+            <%= link_to "Settings", "#", class: "nav-link text-white-50" %>
+          </li>
+          <li class="nav-item">
+            <%= link_to "AI Assistant", "#", class: "nav-link text-white-50" %>
+          </li>
+        </ul>
+        <hr class="text-white-50">
+        <small class="text-white-50"><%= current_studio&.name %></small>
+      </nav>
+
+      <!-- Main content -->
+      <main class="flex-grow-1 p-4">
+        <% if notice.present? %>
+          <div class="alert alert-success alert-dismissible fade show" role="alert">
+            <%= notice %>
+            <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+          </div>
+        <% end %>
+        <% if alert.present? %>
+          <div class="alert alert-danger alert-dismissible fade show" role="alert">
+            <%= alert %>
+            <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+          </div>
+        <% end %>
+
+        <%= yield %>
+      </main>
+    </div>
+  </body>
+</html>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,7 +27,40 @@ Rails.application.routes.draw do
   resource :dashboard, only: [:show]
 
   resources :visits, only: [:create]
-  # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
+
+  # === Admin namespace ===
+  namespace :admin do
+    # Navid's areas
+    resource :dashboard, only: [:show]
+    resources :rewards
+    resources :class_configs, only: [:index, :update]
+    resources :deals do
+      patch :update_referral, on: :collection
+    end
+    resources :members, only: [:index, :show, :export] do
+      post :points, to: "member_points#create", on: :member
+      post :rewards, to: "member_rewards#create", on: :member
+      get :export, on: :collection
+    end
+
+    # Raj's areas
+    resource :checkin_settings, only: [:show, :update] do
+      get :nfc_guide
+      post :test
+    end
+    resources :mindbody_matches, only: [:index] do
+      member do
+        post :confirm
+        post :reject
+      end
+    end
+    resources :mindbody_conflicts, only: [:show]
+    resources :notification_templates, only: [:index, :update]
+    resources :broadcasts, only: [:index, :create]
+    resource :assistant, only: [:show], controller: "assistant" do
+      post :respond
+    end
+  end
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.

--- a/db/migrate/20260312115205_add_role_to_users.rb
+++ b/db/migrate/20260312115205_add_role_to_users.rb
@@ -1,0 +1,5 @@
+class AddRoleToUsers < ActiveRecord::Migration[8.1]
+  def change
+    add_column :users, :role, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_11_181158) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_12_115205) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -34,6 +34,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_11_181158) do
     t.datetime "created_at", null: false
     t.boolean "status"
     t.bigint "studio_id", null: false
+    t.string "title"
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
     t.index ["studio_id"], name: "index_chats_on_studio_id"
@@ -91,6 +92,20 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_11_181158) do
     t.index ["chat_id"], name: "index_messages_on_chat_id"
   end
 
+  create_table "mindbody_clients", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "email"
+    t.string "first_name"
+    t.string "last_name"
+    t.string "mindbody_client_id"
+    t.string "phone"
+    t.bigint "studio_id", null: false
+    t.datetime "updated_at", null: false
+    t.index ["studio_id", "mindbody_client_id"], name: "index_mindbody_clients_on_studio_id_and_mindbody_client_id", unique: true
+    t.index ["studio_id", "phone"], name: "index_mindbody_clients_on_studio_id_and_phone"
+    t.index ["studio_id"], name: "index_mindbody_clients_on_studio_id"
+  end
+
   create_table "mindbody_links", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "linked_at"
@@ -100,6 +115,31 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_11_181158) do
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
     t.index ["user_id"], name: "index_mindbody_links_on_user_id"
+  end
+
+  create_table "notifications", force: :cascade do |t|
+    t.string "body"
+    t.datetime "created_at", null: false
+    t.string "notification_type"
+    t.string "path"
+    t.datetime "read_at"
+    t.datetime "sent_at"
+    t.bigint "studio_id", null: false
+    t.string "title"
+    t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.index ["studio_id"], name: "index_notifications_on_studio_id"
+    t.index ["user_id"], name: "index_notifications_on_user_id"
+  end
+
+  create_table "push_subscriptions", force: :cascade do |t|
+    t.string "auth_key"
+    t.datetime "created_at", null: false
+    t.string "endpoint"
+    t.string "p256dh_key"
+    t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.index ["user_id"], name: "index_push_subscriptions_on_user_id"
   end
 
   create_table "referrals", force: :cascade do |t|
@@ -203,6 +243,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_11_181158) do
     t.datetime "remember_created_at"
     t.datetime "reset_password_sent_at"
     t.string "reset_password_token"
+    t.integer "role", default: 0, null: false
     t.integer "total_points"
     t.integer "total_visits"
     t.datetime "updated_at", null: false
@@ -234,7 +275,11 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_11_181158) do
   add_foreign_key "deal_claims", "users"
   add_foreign_key "deals", "studios"
   add_foreign_key "messages", "chats"
+  add_foreign_key "mindbody_clients", "studios"
   add_foreign_key "mindbody_links", "users"
+  add_foreign_key "notifications", "studios"
+  add_foreign_key "notifications", "users"
+  add_foreign_key "push_subscriptions", "users"
   add_foreign_key "referrals", "users", column: "referred_id"
   add_foreign_key "referrals", "users", column: "referrer_id"
   add_foreign_key "reward_redemptions", "rewards"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -59,7 +59,8 @@ owner = User.create!(
   last_name: "Lopez",
   phone: 610001111,
   referred_by: nil,
-  last_visit_at: nil
+  last_visit_at: nil,
+  role: :admin
 )
 
 puts "Creating studios..."


### PR DESCRIPTION
## Summary
- Adds `role` column to users: `customer` (0, default) and `admin` (1)
- `Admin::BaseController` with Devise auth + `admin?` check + `current_studio` helper
- Admin layout with Bootstrap sidebar (shared navigation for all admin tabs)
- Route skeleton for all admin controllers (Raj + Navid areas)
- Seeds: studio owner marked as admin

## Test plan
- [ ] Run `bin/rails db:migrate` — role column added
- [ ] `User.new.customer?` returns true (default)
- [ ] Admin pages redirect non-admin users to root
- [ ] Login as owner@tapinstudio.com → can access /admin/*

🤖 Generated with [Claude Code](https://claude.com/claude-code)